### PR TITLE
add minimal-editorial design system foundation

### DIFF
--- a/apps/wanieldeiss/project.json
+++ b/apps/wanieldeiss/project.json
@@ -22,7 +22,11 @@
             "input": "apps/wanieldeiss/public"
           }
         ],
-        "styles": ["apps/wanieldeiss/src/styles.css"],
+        "styles": [
+          "node_modules/@fontsource-variable/inter/index.css",
+          "node_modules/@fontsource-variable/fraunces/index.css",
+          "apps/wanieldeiss/src/styles.css"
+        ],
         "scripts": []
       },
       "configurations": {

--- a/apps/wanieldeiss/src/app/ui/index.ts
+++ b/apps/wanieldeiss/src/app/ui/index.ts
@@ -1,0 +1,6 @@
+export { ThemeService } from './theme/theme.service';
+export type { Theme } from './theme/theme.service';
+export { ThemeToggleComponent } from './theme/theme-toggle.component';
+export { ReducedMotionService } from './theme/reduced-motion.service';
+export { ContainerComponent } from './layout/container.component';
+export type { ContainerSize } from './layout/container.component';

--- a/apps/wanieldeiss/src/app/ui/layout/container.component.ts
+++ b/apps/wanieldeiss/src/app/ui/layout/container.component.ts
@@ -1,0 +1,39 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  input,
+} from '@angular/core';
+
+export type ContainerSize = 'narrow' | 'prose' | 'page' | 'wide';
+
+const SIZE_MAX_WIDTH: Record<ContainerSize, string> = {
+  narrow: 'max-w-[var(--container-narrow)]',
+  prose: 'max-w-[var(--container-prose)]',
+  page: 'max-w-[var(--container-page)]',
+  wide: 'max-w-[var(--container-wide)]',
+};
+
+/**
+ * Centred content container with the project's standard horizontal padding.
+ * Pick a `size` for the editorial measure: `narrow`, `prose`, `page`
+ * (default), or `wide`.
+ */
+@Component({
+  standalone: true,
+  selector: 'wd-container',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <div [class]="containerClass()">
+      <ng-content />
+    </div>
+  `,
+})
+export class ContainerComponent {
+  readonly size = input<ContainerSize>('page');
+
+  protected readonly containerClass = computed(
+    () =>
+      `mx-auto w-full px-6 sm:px-8 lg:px-12 ${SIZE_MAX_WIDTH[this.size()]}`,
+  );
+}

--- a/apps/wanieldeiss/src/app/ui/theme/reduced-motion.service.ts
+++ b/apps/wanieldeiss/src/app/ui/theme/reduced-motion.service.ts
@@ -13,10 +13,13 @@ export class ReducedMotionService {
   readonly reducedMotion = signal(this.matchesReducedMotion());
 
   constructor() {
-    if (typeof window === 'undefined' || !window.matchMedia) {
+    if (
+      typeof globalThis.window === 'undefined' ||
+      typeof globalThis.matchMedia !== 'function'
+    ) {
       return;
     }
-    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const mql = globalThis.matchMedia('(prefers-reduced-motion: reduce)');
     const handler = (event: MediaQueryListEvent): void =>
       this.reducedMotion.set(event.matches);
     mql.addEventListener('change', handler);
@@ -26,9 +29,12 @@ export class ReducedMotionService {
   }
 
   private matchesReducedMotion(): boolean {
-    if (typeof window === 'undefined' || !window.matchMedia) {
+    if (
+      typeof globalThis.window === 'undefined' ||
+      typeof globalThis.matchMedia !== 'function'
+    ) {
       return false;
     }
-    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    return globalThis.matchMedia('(prefers-reduced-motion: reduce)').matches;
   }
 }

--- a/apps/wanieldeiss/src/app/ui/theme/reduced-motion.service.ts
+++ b/apps/wanieldeiss/src/app/ui/theme/reduced-motion.service.ts
@@ -1,0 +1,34 @@
+import { DestroyRef, Injectable, inject, signal } from '@angular/core';
+
+/**
+ * Signal-backed wrapper around the `prefers-reduced-motion` media query.
+ *
+ * Components consume `reducedMotion()` to opt complex animations out at
+ * runtime. The CSS in `styles.css` already neutralises ordinary transitions
+ * globally — this signal is for cases where the markup itself differs (for
+ * instance, skipping a parallax layer or scroll-driven sequence).
+ */
+@Injectable({ providedIn: 'root' })
+export class ReducedMotionService {
+  readonly reducedMotion = signal(this.matchesReducedMotion());
+
+  constructor() {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return;
+    }
+    const mql = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const handler = (event: MediaQueryListEvent): void =>
+      this.reducedMotion.set(event.matches);
+    mql.addEventListener('change', handler);
+    inject(DestroyRef).onDestroy(() =>
+      mql.removeEventListener('change', handler),
+    );
+  }
+
+  private matchesReducedMotion(): boolean {
+    if (typeof window === 'undefined' || !window.matchMedia) {
+      return false;
+    }
+    return window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  }
+}

--- a/apps/wanieldeiss/src/app/ui/theme/theme-toggle.component.ts
+++ b/apps/wanieldeiss/src/app/ui/theme/theme-toggle.component.ts
@@ -1,0 +1,67 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  computed,
+  inject,
+} from '@angular/core';
+import { ThemeService } from './theme.service';
+
+/**
+ * Minimal switch that flips the active theme via the signal-based
+ * {@link ThemeService}. Renders a sun when dark is active (click → light)
+ * and a moon when light is active (click → dark).
+ */
+@Component({
+  standalone: true,
+  selector: 'wd-theme-toggle',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <button
+      type="button"
+      role="switch"
+      [attr.aria-checked]="theme.isDark()"
+      [attr.aria-label]="label()"
+      [title]="label()"
+      (click)="theme.toggle()"
+      class="inline-flex h-9 w-9 items-center justify-center rounded-full border border-border text-fg-muted transition-colors hover:border-border-strong hover:text-fg-strong focus-visible:outline-hidden focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-2 focus-visible:ring-offset-surface"
+    >
+      @if (theme.isDark()) {
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          class="h-4 w-4"
+          aria-hidden="true"
+        >
+          <circle cx="12" cy="12" r="4" />
+          <path
+            stroke-linecap="round"
+            d="M12 3v1.5M12 19.5V21M3 12h1.5M19.5 12H21M5.636 5.636l1.06 1.06M17.303 17.303l1.061 1.061M5.636 18.364l1.06-1.061M17.303 6.697l1.061-1.061"
+          />
+        </svg>
+      } @else {
+        <svg
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          stroke-width="1.5"
+          class="h-4 w-4"
+          aria-hidden="true"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            d="M21.752 15.002A9.718 9.718 0 0118 15.75c-5.385 0-9.75-4.365-9.75-9.75 0-1.33.266-2.597.748-3.752A9.753 9.753 0 003 11.25C3 16.635 7.365 21 12.75 21a9.753 9.753 0 009.002-5.998z"
+          />
+        </svg>
+      }
+    </button>
+  `,
+})
+export class ThemeToggleComponent {
+  protected readonly theme = inject(ThemeService);
+  protected readonly label = computed(() =>
+    this.theme.isDark() ? 'Switch to light theme' : 'Switch to dark theme',
+  );
+}

--- a/apps/wanieldeiss/src/app/ui/theme/theme.service.ts
+++ b/apps/wanieldeiss/src/app/ui/theme/theme.service.ts
@@ -1,0 +1,60 @@
+import { Injectable, computed, effect, signal } from '@angular/core';
+
+export type Theme = 'light' | 'dark';
+
+const STORAGE_KEY = 'wd-theme';
+const DEFAULT_THEME: Theme = 'dark';
+
+/**
+ * Signal-based theme store. Single source of truth for the active theme.
+ *
+ * - Reads the persisted choice from localStorage on construction.
+ * - Falls back to `dark` (the design-system default) when nothing is stored.
+ * - Mirrors the active theme onto `<html>.dark` so Tailwind's `dark:` variants
+ *   and the semantic CSS variables in `styles.css` resolve correctly.
+ * - The boot script in `index.html` applies the same logic before the first
+ *   paint to prevent a flash of incorrect theme.
+ */
+@Injectable({ providedIn: 'root' })
+export class ThemeService {
+  readonly theme = signal<Theme>(this.readInitialTheme());
+  readonly isDark = computed(() => this.theme() === 'dark');
+
+  constructor() {
+    effect(() => {
+      const next = this.theme();
+      if (typeof document === 'undefined') {
+        return;
+      }
+      document.documentElement.classList.toggle('dark', next === 'dark');
+      try {
+        window.localStorage.setItem(STORAGE_KEY, next);
+      } catch {
+        /* storage unavailable — ignore */
+      }
+    });
+  }
+
+  toggle(): void {
+    this.theme.update((current) => (current === 'dark' ? 'light' : 'dark'));
+  }
+
+  set(theme: Theme): void {
+    this.theme.set(theme);
+  }
+
+  private readInitialTheme(): Theme {
+    if (typeof window === 'undefined') {
+      return DEFAULT_THEME;
+    }
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored === 'light' || stored === 'dark') {
+        return stored;
+      }
+    } catch {
+      /* localStorage may be blocked (Safari private mode, etc.) */
+    }
+    return DEFAULT_THEME;
+  }
+}

--- a/apps/wanieldeiss/src/app/ui/theme/theme.service.ts
+++ b/apps/wanieldeiss/src/app/ui/theme/theme.service.ts
@@ -28,7 +28,7 @@ export class ThemeService {
       }
       document.documentElement.classList.toggle('dark', next === 'dark');
       try {
-        window.localStorage.setItem(STORAGE_KEY, next);
+        globalThis.localStorage.setItem(STORAGE_KEY, next);
       } catch {
         /* storage unavailable — ignore */
       }
@@ -44,11 +44,11 @@ export class ThemeService {
   }
 
   private readInitialTheme(): Theme {
-    if (typeof window === 'undefined') {
+    if (typeof globalThis.window === 'undefined') {
       return DEFAULT_THEME;
     }
     try {
-      const stored = window.localStorage.getItem(STORAGE_KEY);
+      const stored = globalThis.localStorage.getItem(STORAGE_KEY);
       if (stored === 'light' || stored === 'dark') {
         return stored;
       }

--- a/apps/wanieldeiss/src/index.html
+++ b/apps/wanieldeiss/src/index.html
@@ -29,7 +29,10 @@
           if (theme === 'dark') {
             document.documentElement.classList.add('dark');
           }
-        } catch (e) {
+        } catch (error) {
+          // localStorage may be blocked (Safari private mode, strict CSP).
+          // Log once so the failure is observable, then fall back to dark.
+          console.warn('[theme-boot] unable to read stored theme', error);
           document.documentElement.classList.add('dark');
         }
       })();

--- a/apps/wanieldeiss/src/index.html
+++ b/apps/wanieldeiss/src/index.html
@@ -5,7 +5,34 @@
     <title>Daniel Weiß</title>
     <base href="/" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="dark light" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
+
+    <!-- Editorial typography: Fraunces (display) + Inter (body) -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      rel="stylesheet"
+      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300..700&family=Inter:wght@400;500;600;700&display=swap"
+    />
+
+    <!--
+      Theme boot — runs before the body parses to apply the persisted (or default)
+      theme class on <html>. Prevents a flash of light content on dark default.
+    -->
+    <script>
+      (function () {
+        try {
+          var stored = localStorage.getItem('wd-theme');
+          var theme = stored === 'light' || stored === 'dark' ? stored : 'dark';
+          if (theme === 'dark') {
+            document.documentElement.classList.add('dark');
+          }
+        } catch (e) {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
   </head>
   <body>
     <wd-root></wd-root>

--- a/apps/wanieldeiss/src/index.html
+++ b/apps/wanieldeiss/src/index.html
@@ -8,13 +8,14 @@
     <meta name="color-scheme" content="dark light" />
     <link rel="icon" type="image/x-icon" href="favicon.ico" />
 
-    <!-- Editorial typography: Fraunces (display) + Inter (body) -->
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link
-      rel="stylesheet"
-      href="https://fonts.googleapis.com/css2?family=Fraunces:opsz,wght@9..144,300..700&family=Inter:wght@400;500;600;700&display=swap"
-    />
+    <!--
+      Editorial typography (Fraunces for display, Inter for body) is
+      self-hosted via the @fontsource-variable/* packages declared in
+      apps/wanieldeiss/project.json → build.options.styles. Keeping the
+      fonts local removes the third-party network dependency, preserves
+      user privacy (GDPR), and resolves the Sonar Web:S5725 hotspot
+      (Subresource Integrity) that applies to remote stylesheets.
+    -->
 
     <!--
       Theme boot — runs before the body parses to apply the persisted (or default)

--- a/apps/wanieldeiss/src/styles.css
+++ b/apps/wanieldeiss/src/styles.css
@@ -1,14 +1,127 @@
 @import 'tailwindcss';
 
-@custom-variant dark (&:is(.dark *));
+/* ---------------------------------------------------------------------------
+   Dark mode strategy
+   ---------------------------------------------------------------------------
+   `class`-based: any element carrying `.dark` (or living below one) opts in.
+   The default is dark — see the inline boot script in index.html that adds
+   the class to <html> before the first paint to avoid a flash.
+*/
+@custom-variant dark (&:where(.dark, .dark *));
 
-/*
-  The default border color has changed to `currentcolor` in Tailwind CSS v4,
-  so we've added these compatibility styles to make sure everything still
-  looks the same as it did with Tailwind CSS v3.
+/* ---------------------------------------------------------------------------
+   Semantic theme tokens (light → overridden in `.dark`)
+   ---------------------------------------------------------------------------
+   These CSS variables are the single source of truth for colour. The Tailwind
+   utilities below reference them via `@theme inline`, so swapping themes is
+   just a class change at runtime.
+*/
+:root {
+  /* Surfaces */
+  --surface-base: var(--color-stone-50);
+  --surface-elevated: #ffffff;
+  --surface-sunken: var(--color-stone-100);
 
-  If we ever want to remove these styles, we need to add an explicit border
-  color utility to any element that depends on these defaults.
+  /* Foreground */
+  --fg-strong: var(--color-stone-900);
+  --fg-default: var(--color-stone-800);
+  --fg-muted: var(--color-stone-600);
+  --fg-subtle: var(--color-stone-400);
+  --fg-on-accent: var(--color-stone-50);
+
+  /* Accent — emerald */
+  --accent: var(--color-emerald-600);
+  --accent-hover: var(--color-emerald-700);
+  --accent-soft: color-mix(in oklch, var(--color-emerald-500) 14%, transparent);
+
+  /* Borders & rules */
+  --border-default: var(--color-stone-200);
+  --border-strong: var(--color-stone-300);
+  --rule: var(--color-stone-300);
+}
+
+.dark {
+  --surface-base: var(--color-stone-950);
+  --surface-elevated: var(--color-stone-900);
+  --surface-sunken: #0a0907;
+
+  --fg-strong: var(--color-stone-50);
+  --fg-default: var(--color-stone-200);
+  --fg-muted: var(--color-stone-400);
+  --fg-subtle: var(--color-stone-500);
+  --fg-on-accent: var(--color-stone-950);
+
+  --accent: var(--color-emerald-400);
+  --accent-hover: var(--color-emerald-300);
+  --accent-soft: color-mix(in oklch, var(--color-emerald-500) 22%, transparent);
+
+  --border-default: var(--color-stone-800);
+  --border-strong: var(--color-stone-700);
+  --rule: var(--color-stone-700);
+}
+
+/* ---------------------------------------------------------------------------
+   Tailwind theme — extend utilities & expose the semantic tokens
+   ---------------------------------------------------------------------------
+   `@theme inline` keeps the CSS-variable reference so utilities respond to
+   the active colour scheme at runtime instead of being baked in at build time.
+*/
+@theme inline {
+  /* Surfaces */
+  --color-surface: var(--surface-base);
+  --color-surface-elevated: var(--surface-elevated);
+  --color-surface-sunken: var(--surface-sunken);
+
+  /* Foreground */
+  --color-fg: var(--fg-default);
+  --color-fg-strong: var(--fg-strong);
+  --color-fg-muted: var(--fg-muted);
+  --color-fg-subtle: var(--fg-subtle);
+  --color-fg-on-accent: var(--fg-on-accent);
+
+  /* Accent */
+  --color-accent: var(--accent);
+  --color-accent-hover: var(--accent-hover);
+  --color-accent-soft: var(--accent-soft);
+
+  /* Borders */
+  --color-border: var(--border-default);
+  --color-border-strong: var(--border-strong);
+  --color-rule: var(--rule);
+}
+
+@theme {
+  /* Typography — Fraunces for editorial display, Inter for body */
+  --font-sans:
+    'Inter', ui-sans-serif, system-ui, -apple-system, 'Segoe UI', sans-serif;
+  --font-display:
+    'Fraunces', ui-serif, Georgia, 'Times New Roman', serif;
+  --font-mono:
+    'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+
+  /* Container max-widths — drives `max-w-narrow` / `max-w-page` / `max-w-wide`
+     plus the built-in `max-w-prose` (overridden to a tighter editorial measure). */
+  --container-prose: 65ch;
+  --container-narrow: 42rem;
+  --container-page: 76rem;
+  --container-wide: 88rem;
+
+  /* Editorial spacing scale — generates `p-gutter`, `mt-section`, etc. */
+  --spacing-gutter: 1.5rem;
+  --spacing-gutter-lg: 3rem;
+  --spacing-section: 6rem;
+  --spacing-section-lg: 9rem;
+
+  /* Editorial tracking & leading */
+  --tracking-display: -0.02em;
+  --tracking-eyebrow: 0.18em;
+  --leading-display: 1.05;
+  --leading-prose: 1.7;
+}
+
+/* ---------------------------------------------------------------------------
+   Base layer — global element defaults
+   ---------------------------------------------------------------------------
 */
 @layer base {
   *,
@@ -16,11 +129,62 @@
   ::before,
   ::backdrop,
   ::file-selector-button {
-    border-color: var(--color-gray-200, currentcolor);
+    border-color: var(--color-border, currentcolor);
+  }
+
+  html {
+    scroll-behavior: smooth;
+    color-scheme: light;
+    -webkit-text-size-adjust: 100%;
+  }
+
+  html.dark {
+    color-scheme: dark;
+  }
+
+  body {
+    background-color: var(--color-surface);
+    color: var(--color-fg);
+    font-family: var(--font-sans);
+    font-feature-settings: 'cv11', 'ss01';
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    transition: background-color 200ms ease, color 200ms ease;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    font-family: var(--font-display);
+    color: var(--color-fg-strong);
+    letter-spacing: var(--tracking-display);
+    line-height: var(--leading-display);
+    text-wrap: balance;
+  }
+
+  ::selection {
+    background-color: var(--accent-soft);
+    color: var(--color-fg-strong);
   }
 }
 
-/* You can add global styles to this file, and also import other style files */
-html {
-  scroll-behavior: smooth;
+/* ---------------------------------------------------------------------------
+   prefers-reduced-motion — respect the user globally
+   ---------------------------------------------------------------------------
+   Tailwind v4 ships `motion-safe:` / `motion-reduce:` variants out of the box;
+   this block hardens the default so any rogue transition or animation is
+   neutralised when the user has opted out at the OS level.
+*/
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.001ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,8 @@
     "@angular/platform-browser": "21.2.9",
     "@angular/platform-browser-dynamic": "21.2.9",
     "@angular/router": "21.2.9",
+    "@fontsource-variable/fraunces": "^5.2.0",
+    "@fontsource-variable/inter": "^5.2.0",
     "@fortawesome/angular-fontawesome": "^4.0.0",
     "@fortawesome/free-solid-svg-icons": "^6.6.0",
     "@nx/angular": "22.6.5",


### PR DESCRIPTION
Sets up the typography, palette, theme tokens, and primitives the portfolio rebuild will sit on. Page contents intentionally untouched.

- styles.css: stone neutrals + emerald accent, semantic CSS variables (surface/fg/accent/border) consumed via @theme inline so utilities respond to the active theme. Adds Fraunces/Inter font tokens, custom container max-widths, editorial spacing scale, base element defaults and a global prefers-reduced-motion guard.
- index.html: preconnect + load Fraunces + Inter from Google Fonts and a tiny pre-paint boot script that applies the persisted (or default dark) theme class on <html> to avoid FOUC.
- ui/theme/theme.service.ts: signal-based store, persists to localStorage, mirrors onto <html>.dark.
- ui/theme/theme-toggle.component.ts: signal-based switch (sun/moon).
- ui/theme/reduced-motion.service.ts: signal wrapper around the prefers-reduced-motion media query for runtime opt-outs.
- ui/layout/container.component.ts: centred container with size input (narrow/prose/page/wide) and consistent horizontal padding.

The existing DarkModeService and header toggle remain in place so nothing on the current pages breaks; they can be migrated to the new ThemeService when the rebuild starts.