### PR TITLE
restyle About section to match the editorial design system

### DIFF
--- a/apps/wanieldeiss/src/app/components/about-me/about-me.component.ts
+++ b/apps/wanieldeiss/src/app/components/about-me/about-me.component.ts
@@ -1,37 +1,52 @@
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
-import { TypingDirective } from '../../directives/typing.directive';
+import {
+  SectionHeaderComponent,
+} from '../section-header/section-header.component';
+import { ContainerComponent } from '../../ui';
 
 @Component({
   selector: 'wd-about-me',
   standalone: true,
-  imports: [TypingDirective],
+  imports: [ContainerComponent, SectionHeaderComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
-    <div class="flex-row md:flex gap-8">
+    <wd-container size="page">
       <div
-        class="font-extrabold text-sky-800 dark:text-sky-50 md:text-7xl text-4xl"
+        class="grid gap-12 md:grid-cols-[minmax(0,14rem)_1fr] md:gap-16 lg:gap-24"
       >
-        About me
+        <div class="md:sticky md:top-28 md:self-start">
+          <wd-section-header index="01" title="About" />
+        </div>
+
+        <div class="max-w-prose">
+          <p
+            class="font-display text-2xl font-light leading-[1.35] tracking-[var(--tracking-display)] text-fg-strong md:text-3xl"
+          >
+            I wrote my first function in 2000 using QBasic — mainly as an
+            unconventional way to solve my math homework.
+          </p>
+
+          <div
+            class="mt-10 space-y-6 text-base leading-[var(--leading-prose)] text-fg-muted md:text-lg"
+          >
+            <p>
+              What started as an experiment quickly turned into a passion that
+              still excites me to this day. Twelve years later, in 2012, I
+              began my first full-time position as a Junior Developer, and
+              even after more than two decades, I'm as fascinated as I was on
+              day one.
+            </p>
+            <p>
+              Today, my focus is on developing web applications, their
+              architecture, and helping the people I lead grow. I love solving
+              complex problems and creating innovative solutions that provide
+              real value, both technically and humanly.
+            </p>
+          </div>
+        </div>
       </div>
-      <div
-        class="font-mono text-sky-600 dark:text-sky-400 md:text-base text-sm max-w-96"
-      >
-        <p>
-          I wrote my first function in 2000 using QBasic – mainly as an
-          unconventional way to solve my math homework. What started as an
-          experiment quickly turned into a passion that still excites me to this
-          day. Twelve years later, in 2012, I began my first full-time position
-          as a Junior Developer, and even after more than two decades, I’m as
-          fascinated as I was on day one.
-        </p>
-        <p>
-          Today, my focus is on developing web applications, their architecture,
-          and helping the people I lead grow. I love solving complex problems
-          and creating innovative solutions that provide real value, both
-          technically and humanly.
-        </p>
-      </div>
-    </div>
+    </wd-container>
   `,
 })
 export class AboutMeComponent {}

--- a/apps/wanieldeiss/src/app/pages/index/index.page.ts
+++ b/apps/wanieldeiss/src/app/pages/index/index.page.ts
@@ -1,6 +1,5 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 
-import { FullSizeDirective } from '../../directives/full-size.directive';
 import { HeroComponent } from '../../components/hero/hero.component';
 import { SectionHeaderComponent } from '../../components/section-header/section-header.component';
 import { ContainerComponent } from '../../ui';
@@ -9,7 +8,6 @@ import { AboutMeComponent } from '../../components/about-me/about-me.component';
 @Component({
   standalone: true,
   imports: [
-    FullSizeDirective,
     HeroComponent,
     AboutMeComponent,
     SectionHeaderComponent,
@@ -21,9 +19,7 @@ import { AboutMeComponent } from '../../components/about-me/about-me.component';
     <wd-hero />
 
     <section id="about" class="scroll-mt-24 py-section">
-      <div class="flex justify-center items-center" wdFullSize="odd">
-        <wd-about-me />
-      </div>
+      <wd-about-me />
     </section>
 
     <section id="experience" class="scroll-mt-24 py-section">


### PR DESCRIPTION
The old about pane used sky-* colours, an extra-bold sans headline, and a hard-coded wdFullSize block background — all pre-design-system choices that clashed with the Hero and the new section shell. The rewrite matches the rest of the page:

- Renders its own wd-container and a sticky left-column wd-section-header labelled "01 // About" so the editorial eyebrow + Fraunces headline treatment is consistent with experience/projects/contact.
- Drops the QBasic hook in a large Fraunces lead paragraph, followed by the rest in Inter body copy with max-w-prose and text-fg-muted.
- Drops the FullSizeDirective wrapper from IndexPage and the unused TypingDirective import from AboutMe (which also clears the NG8113 compiler warning).

https://claude.ai/code/session_01WMSWBbr9eK4jbPRCFNXPSK