### PR TITLE
feat(wanieldeiss): Tech Stack + Projects sections with reusable Card

### DIFF
--- a/apps/wanieldeiss/src/app/components/about-me/about-me.component.ts
+++ b/apps/wanieldeiss/src/app/components/about-me/about-me.component.ts
@@ -3,6 +3,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import {
   SectionHeaderComponent,
 } from '../section-header/section-header.component';
+import { CardComponent } from '../../ui/card/card.component';
 import { ContainerComponent } from '../../ui';
 
 interface KeyFact {
@@ -19,7 +20,7 @@ const KEY_FACTS: readonly KeyFact[] = [
 @Component({
   selector: 'wd-about-me',
   standalone: true,
-  imports: [ContainerComponent, SectionHeaderComponent],
+  imports: [ContainerComponent, SectionHeaderComponent, CardComponent],
   changeDetection: ChangeDetectionStrategy.OnPush,
   template: `
     <wd-container size="page">
@@ -69,16 +70,14 @@ const KEY_FACTS: readonly KeyFact[] = [
 
       <ul class="mt-12 grid gap-4 sm:grid-cols-3 md:mt-16">
         @for (fact of keyFacts; track fact.label) {
-          <li
-            class="rounded-2xl border border-border bg-surface-elevated/40 p-6"
-          >
+          <wd-card>
             <p
               class="font-display text-2xl font-light tracking-[var(--tracking-display)] text-fg-strong md:text-3xl"
             >
               {{ fact.value }}
             </p>
             <p class="mt-2 text-sm text-fg-muted">{{ fact.label }}</p>
-          </li>
+          </wd-card>
         }
       </ul>
     </wd-container>

--- a/apps/wanieldeiss/src/app/components/experience/experience.component.html
+++ b/apps/wanieldeiss/src/app/components/experience/experience.component.html
@@ -3,7 +3,7 @@
     class="grid gap-12 md:grid-cols-[minmax(0,14rem)_1fr] md:gap-16 lg:gap-24"
   >
     <div class="md:sticky md:top-28 md:self-start">
-      <wd-section-header index="02" title="Experience" />
+      <wd-section-header index="03" title="Experience" />
     </div>
 
     <ol class="m-0 list-none p-0">

--- a/apps/wanieldeiss/src/app/components/index.ts
+++ b/apps/wanieldeiss/src/app/components/index.ts
@@ -1,7 +1,9 @@
 export { ExperienceComponent } from './experience/experience.component';
 export { HeroComponent } from './hero/hero.component';
 export { NavComponent } from './nav/nav.component';
+export { ProjectsComponent } from './projects/projects.component';
 export { ScrollProgressComponent } from './scroll-progress/scroll-progress.component';
 export { SectionHeaderComponent } from './section-header/section-header.component';
 export { SkipLinkComponent } from './skip-link/skip-link.component';
 export { SocialIconBarComponent } from './social-icon-bar/social-icon-bar.component';
+export { StackComponent } from './stack/stack.component';

--- a/apps/wanieldeiss/src/app/components/nav/nav.component.spec.ts
+++ b/apps/wanieldeiss/src/app/components/nav/nav.component.spec.ts
@@ -29,14 +29,20 @@ describe('NavComponent', () => {
     expect((logo.nativeElement as HTMLElement).textContent?.trim()).toBe('DW');
   });
 
-  it('should render all four section anchors with correct hrefs', () => {
+  it('should render all section anchors with correct hrefs', () => {
     const anchors = fixture.debugElement.queryAll(
       By.css('nav[aria-label="Primary"] a'),
     );
     const hrefs = anchors.map((a) =>
       (a.nativeElement as HTMLAnchorElement).getAttribute('href'),
     );
-    expect(hrefs).toEqual(['#about', '#experience', '#projects', '#contact']);
+    expect(hrefs).toEqual([
+      '#about',
+      '#stack',
+      '#experience',
+      '#projects',
+      '#contact',
+    ]);
   });
 
   it('should render the theme toggle', () => {

--- a/apps/wanieldeiss/src/app/components/nav/nav.component.ts
+++ b/apps/wanieldeiss/src/app/components/nav/nav.component.ts
@@ -25,6 +25,7 @@ interface NavLink {
 
 const NAV_LINKS: readonly NavLink[] = [
   { id: 'about', label: 'About' },
+  { id: 'stack', label: 'Stack' },
   { id: 'experience', label: 'Experience' },
   { id: 'projects', label: 'Projects' },
   { id: 'contact', label: 'Contact' },

--- a/apps/wanieldeiss/src/app/components/projects/projects.component.css
+++ b/apps/wanieldeiss/src/app/components/projects/projects.component.css
@@ -1,0 +1,20 @@
+.project-card {
+  transition:
+    transform 280ms cubic-bezier(0.22, 0.8, 0.22, 1),
+    border-color 280ms cubic-bezier(0.22, 0.8, 0.22, 1),
+    box-shadow 280ms cubic-bezier(0.22, 0.8, 0.22, 1);
+}
+
+.project-card:hover {
+  transform: translateY(-2px);
+  border-color: var(--color-accent);
+  box-shadow: 0 0 20px oklch(from var(--color-accent) l c h / 0.12);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .project-card,
+  .project-card:hover {
+    transform: none;
+    transition: none;
+  }
+}

--- a/apps/wanieldeiss/src/app/components/projects/projects.component.html
+++ b/apps/wanieldeiss/src/app/components/projects/projects.component.html
@@ -1,0 +1,78 @@
+<wd-container size="page">
+  <wd-section-header index="04" title="Projects" />
+
+  <div class="grid gap-8 md:grid-cols-2">
+    @for (project of projects; track project.title) {
+      <wd-card class="project-card group">
+        <h3
+          class="font-display text-2xl font-light tracking-[var(--tracking-display)] text-fg-strong"
+        >
+          {{ project.title }}
+        </h3>
+        <p class="mt-2 text-fg-muted">{{ project.description }}</p>
+
+        <div class="mt-6 space-y-4">
+          <div>
+            <p
+              class="text-xs font-medium uppercase tracking-[var(--tracking-eyebrow)] text-accent"
+            >
+              Problem
+            </p>
+            <p class="mt-1 text-sm text-fg-muted">{{ project.problem }}</p>
+          </div>
+          <div>
+            <p
+              class="text-xs font-medium uppercase tracking-[var(--tracking-eyebrow)] text-accent"
+            >
+              Solution
+            </p>
+            <p class="mt-1 text-sm text-fg-muted">{{ project.solution }}</p>
+          </div>
+          <div>
+            <p
+              class="text-xs font-medium uppercase tracking-[var(--tracking-eyebrow)] text-accent"
+            >
+              Impact
+            </p>
+            <p class="mt-1 text-sm text-fg-muted">{{ project.impact }}</p>
+          </div>
+        </div>
+
+        <div class="mt-5 flex flex-wrap gap-2">
+          @for (tag of project.tags; track tag) {
+            <span
+              class="inline-flex rounded-full border border-border bg-surface px-3 py-1 text-xs text-fg-muted"
+            >
+              {{ tag }}
+            </span>
+          }
+        </div>
+
+        @if (project.url) {
+          <a
+            [href]="project.url"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="focus-ring mt-5 inline-flex items-center gap-1.5 text-sm text-accent transition-colors hover:text-accent-hover"
+          >
+            View project
+            <svg
+              viewBox="0 0 16 16"
+              fill="none"
+              stroke="currentColor"
+              stroke-width="1.5"
+              class="h-3.5 w-3.5"
+              aria-hidden="true"
+            >
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                d="M6.5 3.5h6m0 0v6m0-6L3.5 12.5"
+              />
+            </svg>
+          </a>
+        }
+      </wd-card>
+    }
+  </div>
+</wd-container>

--- a/apps/wanieldeiss/src/app/components/projects/projects.component.spec.ts
+++ b/apps/wanieldeiss/src/app/components/projects/projects.component.spec.ts
@@ -1,0 +1,45 @@
+import { TestBed } from '@angular/core/testing';
+
+import { ProjectsComponent } from './projects.component';
+import { PROJECTS } from './projects.data';
+
+describe('ProjectsComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProjectsComponent],
+    }).compileComponents();
+  });
+
+  it('creates the component', () => {
+    const fixture = TestBed.createComponent(ProjectsComponent);
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('renders one card per project', () => {
+    const fixture = TestBed.createComponent(ProjectsComponent);
+    fixture.detectChanges();
+    const cards = fixture.nativeElement.querySelectorAll('wd-card');
+    expect(cards.length).toBe(PROJECTS.length);
+  });
+
+  it('renders titles and descriptions', () => {
+    const fixture = TestBed.createComponent(ProjectsComponent);
+    fixture.detectChanges();
+    const text = fixture.nativeElement.textContent ?? '';
+    for (const project of PROJECTS) {
+      expect(text).toContain(project.title);
+      expect(text).toContain(project.description);
+    }
+  });
+
+  it('renders external link only for projects with a URL', () => {
+    const fixture = TestBed.createComponent(ProjectsComponent);
+    fixture.detectChanges();
+    const links = fixture.nativeElement.querySelectorAll(
+      'a[target="_blank"]',
+    );
+    const projectsWithUrl = PROJECTS.filter((p) => p.url);
+    expect(links.length).toBe(projectsWithUrl.length);
+  });
+});

--- a/apps/wanieldeiss/src/app/components/projects/projects.component.ts
+++ b/apps/wanieldeiss/src/app/components/projects/projects.component.ts
@@ -1,0 +1,20 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import {
+  SectionHeaderComponent,
+} from '../section-header/section-header.component';
+import { CardComponent } from '../../ui/card/card.component';
+import { ContainerComponent } from '../../ui';
+import { PROJECTS } from './projects.data';
+
+@Component({
+  standalone: true,
+  selector: 'wd-projects',
+  imports: [ContainerComponent, SectionHeaderComponent, CardComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  templateUrl: './projects.component.html',
+  styleUrl: './projects.component.css',
+})
+export class ProjectsComponent {
+  protected readonly projects = PROJECTS;
+}

--- a/apps/wanieldeiss/src/app/components/projects/projects.data.ts
+++ b/apps/wanieldeiss/src/app/components/projects/projects.data.ts
@@ -1,0 +1,33 @@
+export interface Project {
+  readonly title: string;
+  readonly description: string;
+  readonly problem: string;
+  readonly solution: string;
+  readonly impact: string;
+  readonly tags: readonly string[];
+  readonly url?: string;
+}
+
+export const PROJECTS: readonly Project[] = [
+  {
+    title: 'Placeholder Project 1',
+    description:
+      'Kurzbeschreibung des Projekts — was es ist und warum es existiert.',
+    problem: 'Platzhalter — welches Problem wurde gelöst.',
+    solution:
+      'Platzhalter — technischer Ansatz und eingesetzte Technologien.',
+    impact: 'Platzhalter — messbares Ergebnis oder Verbesserung.',
+    tags: ['Angular', 'TypeScript', 'Tailwind'],
+    url: 'https://example.com',
+  },
+  {
+    title: 'Placeholder Project 2',
+    description:
+      'Kurzbeschreibung des Projekts — was es ist und warum es existiert.',
+    problem: 'Platzhalter — welches Problem wurde gelöst.',
+    solution:
+      'Platzhalter — technischer Ansatz und eingesetzte Technologien.',
+    impact: 'Platzhalter — messbares Ergebnis oder Verbesserung.',
+    tags: ['Node.js', 'PostgreSQL'],
+  },
+];

--- a/apps/wanieldeiss/src/app/components/stack/stack.component.spec.ts
+++ b/apps/wanieldeiss/src/app/components/stack/stack.component.spec.ts
@@ -1,0 +1,34 @@
+import { TestBed } from '@angular/core/testing';
+
+import { StackComponent } from './stack.component';
+import { STACK } from './stack.data';
+
+describe('StackComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [StackComponent],
+    }).compileComponents();
+  });
+
+  it('creates the component', () => {
+    const fixture = TestBed.createComponent(StackComponent);
+    fixture.detectChanges();
+    expect(fixture.componentInstance).toBeTruthy();
+  });
+
+  it('renders one card per stack group', () => {
+    const fixture = TestBed.createComponent(StackComponent);
+    fixture.detectChanges();
+    const cards = fixture.nativeElement.querySelectorAll('wd-card');
+    expect(cards.length).toBe(STACK.length);
+  });
+
+  it('renders group titles', () => {
+    const fixture = TestBed.createComponent(StackComponent);
+    fixture.detectChanges();
+    const text = fixture.nativeElement.textContent ?? '';
+    for (const group of STACK) {
+      expect(text).toContain(group.title);
+    }
+  });
+});

--- a/apps/wanieldeiss/src/app/components/stack/stack.component.ts
+++ b/apps/wanieldeiss/src/app/components/stack/stack.component.ts
@@ -1,0 +1,44 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import {
+  SectionHeaderComponent,
+} from '../section-header/section-header.component';
+import { CardComponent } from '../../ui/card/card.component';
+import { ContainerComponent } from '../../ui';
+import { STACK } from './stack.data';
+
+@Component({
+  standalone: true,
+  selector: 'wd-stack',
+  imports: [ContainerComponent, SectionHeaderComponent, CardComponent],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `
+    <wd-container size="page">
+      <wd-section-header index="02" title="Stack" />
+
+      <div class="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        @for (group of groups; track group.title) {
+          <wd-card>
+            <h3
+              class="font-display text-lg font-light tracking-[var(--tracking-display)] text-fg-strong"
+            >
+              {{ group.title }}
+            </h3>
+            <div class="mt-4 flex flex-wrap gap-2">
+              @for (skill of group.skills; track skill) {
+                <span
+                  class="inline-flex rounded-full border border-border bg-surface px-3 py-1 text-xs text-fg-muted transition-colors hover:border-accent hover:text-fg-strong"
+                >
+                  {{ skill }}
+                </span>
+              }
+            </div>
+          </wd-card>
+        }
+      </div>
+    </wd-container>
+  `,
+})
+export class StackComponent {
+  protected readonly groups = STACK;
+}

--- a/apps/wanieldeiss/src/app/components/stack/stack.data.ts
+++ b/apps/wanieldeiss/src/app/components/stack/stack.data.ts
@@ -1,0 +1,29 @@
+export interface StackGroup {
+  readonly title: string;
+  readonly skills: readonly string[];
+}
+
+export const STACK: readonly StackGroup[] = [
+  {
+    title: 'Frontend',
+    skills: ['Angular', 'TypeScript', 'RxJS', 'Tailwind CSS', 'NgRx', 'Nx'],
+  },
+  {
+    title: 'Backend',
+    skills: ['Node.js', 'NestJS', 'PostgreSQL', 'REST', 'GraphQL'],
+  },
+  {
+    title: 'Data',
+    skills: ['Python', 'Pandas', 'SQL', 'ETL Pipelines', 'BigQuery'],
+  },
+  {
+    title: 'Leadership',
+    skills: [
+      'Agile / Scrum',
+      'Code Reviews',
+      'Mentoring',
+      'Architecture Decisions',
+      'Hiring',
+    ],
+  },
+];

--- a/apps/wanieldeiss/src/app/pages/index/index.page.ts
+++ b/apps/wanieldeiss/src/app/pages/index/index.page.ts
@@ -4,14 +4,18 @@ import { HeroComponent } from '../../components/hero/hero.component';
 import { SectionHeaderComponent } from '../../components/section-header/section-header.component';
 import { ContainerComponent } from '../../ui';
 import { AboutMeComponent } from '../../components/about-me/about-me.component';
+import { StackComponent } from '../../components/stack/stack.component';
 import { ExperienceComponent } from '../../components/experience/experience.component';
+import { ProjectsComponent } from '../../components/projects/projects.component';
 
 @Component({
   standalone: true,
   imports: [
     HeroComponent,
     AboutMeComponent,
+    StackComponent,
     ExperienceComponent,
+    ProjectsComponent,
     SectionHeaderComponent,
     ContainerComponent,
   ],
@@ -24,21 +28,21 @@ import { ExperienceComponent } from '../../components/experience/experience.comp
       <wd-about-me />
     </section>
 
+    <section id="stack" class="scroll-mt-24 py-section">
+      <wd-stack />
+    </section>
+
     <section id="experience" class="scroll-mt-24 py-section">
       <wd-experience />
     </section>
 
     <section id="projects" class="scroll-mt-24 py-section">
-      <wd-container size="page">
-        <wd-section-header index="03" title="Projects">
-          <p>Placeholder — content arrives with the projects task.</p>
-        </wd-section-header>
-      </wd-container>
+      <wd-projects />
     </section>
 
     <section id="contact" class="scroll-mt-24 py-section">
       <wd-container size="page">
-        <wd-section-header index="04" title="Contact">
+        <wd-section-header index="05" title="Contact">
           <p>Placeholder — content arrives with the contact task.</p>
         </wd-section-header>
       </wd-container>

--- a/apps/wanieldeiss/src/app/ui/card/card.component.spec.ts
+++ b/apps/wanieldeiss/src/app/ui/card/card.component.spec.ts
@@ -1,0 +1,33 @@
+import { TestBed } from '@angular/core/testing';
+import { Component } from '@angular/core';
+
+import { CardComponent } from './card.component';
+
+@Component({
+  standalone: true,
+  imports: [CardComponent],
+  template: `<wd-card>Test content</wd-card>`,
+})
+class TestHost {}
+
+describe('CardComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [TestHost],
+    }).compileComponents();
+  });
+
+  it('renders projected content', () => {
+    const fixture = TestBed.createComponent(TestHost);
+    fixture.detectChanges();
+    expect(fixture.nativeElement.textContent).toContain('Test content');
+  });
+
+  it('applies base card classes on host', () => {
+    const fixture = TestBed.createComponent(TestHost);
+    fixture.detectChanges();
+    const card = fixture.nativeElement.querySelector('wd-card');
+    expect(card.classList.contains('rounded-2xl')).toBe(true);
+    expect(card.classList.contains('border')).toBe(true);
+  });
+});

--- a/apps/wanieldeiss/src/app/ui/card/card.component.ts
+++ b/apps/wanieldeiss/src/app/ui/card/card.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+@Component({
+  standalone: true,
+  selector: 'wd-card',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  template: `<ng-content />`,
+  host: {
+    class:
+      'block rounded-2xl border border-border bg-surface-elevated/40 p-6 transition-colors',
+  },
+})
+export class CardComponent {}

--- a/apps/wanieldeiss/src/app/ui/index.ts
+++ b/apps/wanieldeiss/src/app/ui/index.ts
@@ -4,3 +4,4 @@ export { ThemeToggleComponent } from './theme/theme-toggle.component';
 export { ReducedMotionService } from './theme/reduced-motion.service';
 export { ContainerComponent } from './layout/container.component';
 export type { ContainerSize } from './layout/container.component';
+export { CardComponent } from './card/card.component';


### PR DESCRIPTION
- Card primitive (ui/card/) extracted from About key-facts pattern; AboutMe refactored to use <wd-card>
- Stack section: 4 category cards (Frontend/Backend/Data/Leadership) with skill pills; pill hover shows accent border
- Projects section: 2 placeholder cards with Problem/Solution/Impact micro-sections, tags, optional external link (new tab), hover lift + border glow (reduced-motion guarded)
- Nav updated with fifth 'Stack' link between About and Experience
- Section indices renumbered: About 01, Stack 02, Experience 03, Projects 04, Contact 05

https://claude.ai/code/session_01WMSWBbr9eK4jbPRCFNXPSK